### PR TITLE
fix nil-pointer dereference in assignSingleChildProperty

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -378,8 +378,8 @@ func parseVertexDataInner(element *Element, name, idxName string) ([]int, Vertex
 
 func parseTexture(scene *Scene, element *Element) *Texture {
 	texture := NewTexture(scene, element)
-	assignSingleChildProperty(element, "FileName", texture.filename)
-	assignSingleChildProperty(element, "RelativeFilename", texture.relativeFilename)
+	assignSingleChildProperty(element, "FileName", &texture.filename)
+	assignSingleChildProperty(element, "RelativeFilename", &texture.relativeFilename)
 	return texture
 }
 

--- a/property.go
+++ b/property.go
@@ -134,10 +134,10 @@ func findChildren(element *Element, id string) []*Element {
 	return []*Element{}
 }
 
-func assignSingleChildProperty(element *Element, id string, dv *DataView) bool {
+func assignSingleChildProperty(element *Element, id string, dv **DataView) bool {
 	prop := findSingleChildProperty(element, id)
 	if prop != nil {
-		*dv = *prop.value
+		*dv = prop.value
 		return true
 	}
 	return false


### PR DESCRIPTION
Prior to this commit, the ofbx parser would crash with the
following panic as the filename and relativeFilename fields
of Texture were not allocated before call from parseTexture
to assignSingleChildProperty.

	panic: runtime error: invalid memory address or nil pointer dereference
	[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x52a23e]

	goroutine 1 [running]:
	github.com/oakmound/ofbx.assignSingleChildProperty(0xc000302880, 0x566ced, 0x8, 0x0, 0x0)
		/home/u/Desktop/ofbx/property.go:140 +0x5e
	github.com/oakmound/ofbx.parseTexture(0xc00010c000, 0xc000302880, 0x0)
		/home/u/Desktop/ofbx/parse.go:381 +0x85
	github.com/oakmound/ofbx.parseObjects(0xc000078040, 0xc00010c000, 0x0, 0x0, 0x0)
		/home/u/Desktop/ofbx/parse.go:730 +0xb54
	github.com/oakmound/ofbx.Load(0x578628, 0xc00000e028, 0x0, 0x0, 0x0)
		/home/u/Desktop/ofbx/scene.go:101 +0x2ba
	main.parse(0x7ffc4886dabb, 0x31, 0x0, 0x0)
		/home/u/Desktop/ofbx/foo/main.go:28 +0x1b3
	main.main()
		/home/u/Desktop/ofbx/foo/main.go:16 +0xd4