### PR TITLE
add support for FocalLength AnimationCurveNodes

### DIFF
--- a/animationCurve.go
+++ b/animationCurve.go
@@ -144,6 +144,16 @@ func (acn *AnimationCurveNode) stringPrefix(prefix string) string {
 	}
 	s += "bone_link_property=\"" + acn.BoneLinkProp + "\""
 	s += " mode=" + fmt.Sprintf("%d", acn.mode)
+
+	// NOTE: an animation curve node which specify the focal length property has
+	// exactly one curve (FocalLength), rather than three (X,Y,Z).
+	if strings.HasPrefix(acn.Object.name, "FocalLength") {
+		s += "\n" + prefix + "\t"
+		s += " FocalLength: "
+		s += acn.Curves[0].String()
+		return s
+	}
+
 	for i, curve := range acn.Curves {
 		s += "\n" + prefix + "\t"
 		switch i {


### PR DESCRIPTION
This commit fixes a nil-pointer dereference in
AnimationCurve.stringPrefix which was caused by the assumption
that AnimationCurveNodes always contain the Curves. This is true
for most cases (with one curve per X,Y,Z axis). However, the
FocalLength AnimationCurve property has exactly one Curve, not
three.

Panic prior to this commit:

	 5  0x0000000000508d25 in github.com/oakmound/ofbx.(*AnimationCurve).stringPrefix
		 at /home/u/Desktop/ofbx/animationCurve.go:58
	 6  0x0000000000508c9b in github.com/oakmound/ofbx.(*AnimationCurve).String
		 at /home/u/Desktop/ofbx/animationCurve.go:52
	 7  0x0000000000509545 in github.com/oakmound/ofbx.(*Curve).String
		 at /home/u/Desktop/ofbx/animationCurve.go:87
	 8  0x0000000000509d66 in github.com/oakmound/ofbx.(*AnimationCurveNode).stringPrefix
		 at /home/u/Desktop/ofbx/animationCurve.go:162
	 9  0x0000000000508985 in github.com/oakmound/ofbx.(*AnimationLayer).stringPrefix
		 at /home/u/Desktop/ofbx/animation.go:109
	10  0x000000000050838a in github.com/oakmound/ofbx.(*AnimationStack).stringPrefix
		 at /home/u/Desktop/ofbx/animation.go:64
	11  0x000000000052b418 in github.com/oakmound/ofbx.(*Scene).String
		 at /home/u/Desktop/ofbx/scene.go:40
	12  0x00000000004db522 in fmt.(*pp).handleMethods
		 at /home/u/go/src/fmt/print.go:626
	13  0x00000000004db935 in fmt.(*pp).printArg
		 at /home/u/go/src/fmt/print.go:709
	14  0x00000000004e03f4 in fmt.(*pp).doPrintln
		 at /home/u/go/src/fmt/print.go:1169
	15  0x00000000004d8716 in fmt.Fprintln
		 at /home/u/go/src/fmt/print.go:264
	16  0x00000000004d8865 in fmt.Println
		 at /home/u/go/src/fmt/print.go:274
	17  0x0000000000532c70 in main.parse
		 at ./main.go:33
	18  0x00000000005327d4 in main.main
		 at ./main.go:17
	19  0x000000000043d223 in runtime.main
		 at /home/u/go/src/runtime/proc.go:225
	20  0x0000000000470581 in runtime.goexit

Example animation layer with FocalLength AnimationCurveNode:

	 &ofbx.AnimationCurveNode{
		  Object: ofbx.Object{
				id:            0x102c7e21,
				name:          "S\x00\x01AnimCurveNode",
				element:       &ofbx.Element{(CYCLIC REFERENCE)},
				nodeAttribute: nil,
				isNode:        false,
				scene:         &ofbx.Scene{(CYCLIC REFERENCE)},
		  },
		  Curves: {
				{
					 Curve:      &ofbx.AnimationCurve{(CYCLIC REFERENCE)},
					 connection: &ofbx.Connection{typ:1, from:0x2b73613c, to:0x102c7e21, property:"d|X"},
				},
				{
					 Curve:      &ofbx.AnimationCurve{(CYCLIC REFERENCE)},
					 connection: &ofbx.Connection{typ:1, from:0x1def8b85, to:0x102c7e21, property:"d|Y"},
				},
				{
					 Curve:      &ofbx.AnimationCurve{(CYCLIC REFERENCE)},
					 connection: &ofbx.Connection{typ:1, from:0x12919792, to:0x102c7e21, property:"d|Z"},
				},
		  },
		  Bone:         &ofbx.Node{(CYCLIC REFERENCE)},
		  BoneLinkProp: "Lcl Scaling",
		  mode:         0,
	 },
	 &ofbx.AnimationCurveNode{
		  Object: ofbx.Object{
				id:            0x3a35b911,
				name:          "FocalLength\x00\x01AnimCurveNode",
				element:       &ofbx.Element{(CYCLIC REFERENCE)},
				nodeAttribute: nil,
				isNode:        false,
				scene:         &ofbx.Scene{(CYCLIC REFERENCE)},
		  },
		  Curves: {
				{
					 Curve:      &ofbx.AnimationCurve{(CYCLIC REFERENCE)},
					 connection: &ofbx.Connection{typ:1, from:0x10fffb38, to:0x3a35b911, property:"d|FocalLength"},
				},
				{},
				{},
		  },
		  Bone:         nil,
		  BoneLinkProp: "",
		  mode:         0,
	 },